### PR TITLE
Makes the library compatible with both JNA 4.x and 5.x

### DIFF
--- a/src/main/java/com/github/markusbernhardt/proxy/jna/win/WTypes2.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/jna/win/WTypes2.java
@@ -1,6 +1,7 @@
 package com.github.markusbernhardt.proxy.jna.win;
 
 import com.github.markusbernhardt.proxy.util.Logger;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.WTypes;
@@ -39,7 +40,7 @@ public class WTypes2 {
     public static class LPWSTRByReference extends ByReference {
 
         public LPWSTRByReference() {
-            super(Pointer.SIZE);
+            super(Native.POINTER_SIZE);
 			// memory cleanup
 			getPointer().setPointer(0, null);
         }


### PR DESCRIPTION
`com.sun.jna.Pointer#SIZE` is removed in 5.x, but `com.sun.jna.Native#POINTER_SIZE` is present in both.